### PR TITLE
Re-branding: Change to go build foldername and script's referencing it.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type ApiConfig struct {

--- a/build/env.sh
+++ b/build/env.sh
@@ -10,7 +10,7 @@ fi
 # Create fake Go workspace if it doesn't exist yet.
 workspace="$PWD/build/_workspace"
 root="$PWD"
-ethdir="$workspace/src/github.com/sammy007"
+ethdir="$workspace/src/github.com/ellaism"
 if [ ! -L "$ethdir/open-ethereum-pool" ]; then
     mkdir -p "$ethdir"
     cd "$ethdir"

--- a/main.go
+++ b/main.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/yvasiyarov/gorelic"
 
-	"github.com/sammy007/open-ethereum-pool/api"
-	"github.com/sammy007/open-ethereum-pool/payouts"
-	"github.com/sammy007/open-ethereum-pool/proxy"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/api"
+	"github.com/ellaism/open-ethereum-pool/payouts"
+	"github.com/ellaism/open-ethereum-pool/proxy"
+	"github.com/ellaism/open-ethereum-pool/storage"
 )
 
 var cfg proxy.Config

--- a/payouts/payer.go
+++ b/payouts/payer.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 const txCheckInterval = 5 * time.Second

--- a/payouts/unlocker.go
+++ b/payouts/unlocker.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/math"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type UnlockerConfig struct {

--- a/payouts/unlocker_test.go
+++ b/payouts/unlocker_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/storage"
 )
 
 func TestMain(m *testing.M) {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type Config struct {

--- a/proxy/blocks.go
+++ b/proxy/blocks.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 const maxBacklog = 3

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -1,10 +1,10 @@
 package proxy
 
 import (
-	"github.com/sammy007/open-ethereum-pool/api"
-	"github.com/sammy007/open-ethereum-pool/payouts"
-	"github.com/sammy007/open-ethereum-pool/policy"
-	"github.com/sammy007/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/api"
+	"github.com/ellaism/open-ethereum-pool/payouts"
+	"github.com/ellaism/open-ethereum-pool/policy"
+	"github.com/ellaism/open-ethereum-pool/storage"
 )
 
 type Config struct {

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"errors"
 
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 // Allow only lowercase hexadecimal with 0x prefix

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/gorilla/mux"
 
-	"github.com/sammy007/open-ethereum-pool/policy"
-	"github.com/sammy007/open-ethereum-pool/rpc"
-	"github.com/sammy007/open-ethereum-pool/storage"
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/policy"
+	"github.com/ellaism/open-ethereum-pool/rpc"
+	"github.com/ellaism/open-ethereum-pool/storage"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type ProxyServer struct {

--- a/proxy/stratum.go
+++ b/proxy/stratum.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 const (

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type RPCClient struct {

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -9,7 +9,7 @@ import (
 
 	"gopkg.in/redis.v3"
 
-	"github.com/sammy007/open-ethereum-pool/util"
+	"github.com/ellaism/open-ethereum-pool/util"
 )
 
 type Config struct {


### PR DESCRIPTION
Hi @ellaismer & All,

Summary: 

I noticed the scripts reference "sammy007" from the previous fork, as such I have changed this to "ellaism".

Change Details:

- Update folder to "ellaism" from "sammy007"
- Update scripts to reference above folder change.

Change reason: 

-  Aligns with the GitHub URL path naming: https://github.com/ellaism/open-ethereum-pool/
-  Aligns with updated documentation pull request #2 
- This allows users to have a clear difference in change within folder structures and scripts to note the "ellaism" fork and not get confused by a concurrent "sammy007" fork installations.. 

I have also included the `build/env.sh go test -v ./...` output attached: 

`[make_test.txt](https://github.com/ellaism/open-ethereum-pool/files/1715605/make_test.txt)`

Please let me know if any issues / further commits required. ^_^

Thanks, 
👍 