### PR TITLE
Workaround for: Failed to fetch stats from backend: redis: nil

### DIFF
--- a/storage/redis.go
+++ b/storage/redis.go
@@ -730,7 +730,7 @@ func (r *RedisClient) CollectStats(smallWindow time.Duration, maxBlocks, maxPaym
 		return nil
 	})
 
-	if err != nil {
+	if (err != nil) && (err != redis.Nil) {
 		return nil, err
 	}
 


### PR DESCRIPTION
Before any blocks are found I was getting "Failed to fetch stats from backend: redis: nil" and the web UI would not render anything.

This is a work around for this issue that happens when redis returns redis.Nil due to a key not found error in CollectStats.

A similar issue was reported upstream: https://github.com/sammy007/open-ethereum-pool/issues/327

Watching that issue to see how it is resolved.